### PR TITLE
Add namespace requires to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ TWILIO_AUTH_TOKEN=5f4dcc3b5aa765d61d8327deb882cf99
 
 Or set your auth credentials:
 ```clojure
-(tw/set-account-auth! {:account-sid "AC..." :auth-token "5f4dcc3b5aa765d61d8327deb882cf99"})
+(require [twijlio.config :as config])
+
+(config/set-account-auth! {:account-sid "AC..." :auth-token "5f4dcc3b5aa765d61d8327deb882cf99"})
 ```
 
 Send an SMS to (505) 555-1212 from your twilio number (888) 555-2211 with your coolest smiley face.
 ```clojure
+(require [twijlio :as tw])
+
 (tw/send-message "+15055551212" "+18885552211" {:Body "Hey Buddy <(^_^<)"})
 ```
 
@@ -42,12 +46,16 @@ Make a call to (202) 555-1212 from your twilio number (800) 555-2121 and [say he
 
 Use different account temporarily
 ```clojure
-(tw/with-account {:account-sid "AC..." :auth-token "5f4dcc3b5aa765d61d8327deb882cf99"} (tw/make-call "+19005552121" "+13035551212"))
+(require [twijlio.config :as config])
+
+(config/with-account {:account-sid "AC..." :auth-token "5f4dcc3b5aa765d61d8327deb882cf99"} (tw/make-call "+19005552121" "+13035551212"))
 ```
 
 Operate on a subaccount
 ```clojure
-(tw/with-target-sid "AC12345678901234567890123456789012" (get-calls))
+(require [twijlio.config :as config])
+
+(config/with-target-sid "AC12345678901234567890123456789012" (get-calls))
 ```
 
 ## Thanks


### PR DESCRIPTION
Previously the examples were misleading, because it appeared every function was in the same namespace.